### PR TITLE
Add Ghostty Dracula theme

### DIFF
--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,0 +1,31 @@
+# Dracula theme for Ghostty
+# https://draculatheme.com/ghostty
+#
+# Color palette
+# https://spec.draculatheme.com
+
+palette = 0=#21222c
+palette = 1=#ff5555
+palette = 2=#50fa7b
+palette = 3=#f1fa8c
+palette = 4=#bd93f9
+palette = 5=#ff79c6
+palette = 6=#8be9fd
+palette = 7=#f8f8f2
+palette = 8=#6272a4
+palette = 9=#ff6e6e
+palette = 10=#69ff94
+palette = 11=#ffffa5
+palette = 12=#d6acff
+palette = 13=#ff92df
+palette = 14=#a4ffff
+palette = 15=#ffffff
+
+background = #282a36
+foreground = #f8f8f2
+
+cursor-color = #f8f8f2
+cursor-text = #282a36
+
+selection-foreground = #f8f8f2
+selection-background = #44475a

--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,9 +1,3 @@
-# Dracula theme for Ghostty
-# https://draculatheme.com/ghostty
-#
-# Color palette
-# https://spec.draculatheme.com
-
 palette = 0=#21222c
 palette = 1=#ff5555
 palette = 2=#50fa7b
@@ -20,12 +14,9 @@ palette = 12=#d6acff
 palette = 13=#ff92df
 palette = 14=#a4ffff
 palette = 15=#ffffff
-
 background = #282a36
 foreground = #f8f8f2
-
 cursor-color = #f8f8f2
 cursor-text = #282a36
-
 selection-foreground = #f8f8f2
 selection-background = #44475a


### PR DESCRIPTION
## Summary

Adds `ghostty.conf` so Omarchy users on Ghostty get Dracula colors via the optional overlay:

`~/.config/omarchy/current/theme/ghostty.conf`

The palette matches the official [Dracula Ghostty](https://github.com/dracula/ghostty) theme and aligns with the existing `alacritty.toml` in this repository.
